### PR TITLE
fix(init): complete .gitignore and simplify example figure

### DIFF
--- a/crates/nova-cli/src/commands/init.rs
+++ b/crates/nova-cli/src/commands/init.rs
@@ -273,6 +273,15 @@ fn generate_gitignore() -> String {
 /build/
 *.pdf
 
+# NovaType cache
+.nova/
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+.venv/
+
 # Editor files
 .vscode/
 .idea/
@@ -282,9 +291,6 @@ fn generate_gitignore() -> String {
 # OS files
 .DS_Store
 Thumbs.db
-
-# NovaType cache
-.nova/
 "#
     .to_string()
 }
@@ -306,26 +312,31 @@ fn create_python_support(project_dir: &Path) -> Result<()> {
 Example Python figures for NovaType.
 
 Run: nova compile main.typ
+
+Only requires matplotlib (no numpy needed for this example).
+For more complex figures, install numpy: pip install numpy
 """
+
+import math
 
 import nova
 import matplotlib.pyplot as plt
-import numpy as np
 
 
 @nova.figure("example-plot")
 def plot_example():
-    """Generate an example plot."""
-    x = np.linspace(0, 2 * np.pi, 100)
-    y = np.sin(x)
+    """Generate an example sine wave plot."""
+    x = [i * 0.05 for i in range(126)]  # 0 to 2*pi
+    y = [math.sin(v) for v in x]
 
-    plt.figure(figsize=(8, 4))
-    plt.plot(x, y, "b-", linewidth=2, label=r"$\sin(x)$")
-    plt.xlabel("x")
-    plt.ylabel("y")
-    plt.title("Example Plot")
-    plt.legend()
-    plt.grid(True, alpha=0.3)
+    fig, ax = plt.subplots(figsize=(8, 4))
+    ax.plot(x, y, "b-", linewidth=2, label=r"$\sin(x)$")
+    ax.set_xlabel("x")
+    ax.set_ylabel("y")
+    ax.set_title("Example Plot")
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
 "#;
     let example_path = figures_dir.join("example.py");
     std::fs::write(&example_path, example_content)
@@ -450,5 +461,14 @@ mod tests {
         let config = generate_config("my-project", "article", true);
         assert!(config.contains("[python]"));
         assert!(config.contains("figures_dir"));
+    }
+
+    #[test]
+    fn gitignore_includes_python_patterns() {
+        let gitignore = generate_gitignore();
+        assert!(gitignore.contains("__pycache__/"));
+        assert!(gitignore.contains("*.pyc"));
+        assert!(gitignore.contains(".venv/"));
+        assert!(gitignore.contains(".nova/"));
     }
 }


### PR DESCRIPTION
## Summary

- Add Python patterns (`__pycache__/`, `*.pyc`, `*.pyo`, `.venv/`) to generated `.gitignore` — prevents the issue we hit in v0.2.0 where `.pyc` files were tracked
- Simplify scaffold example figure to use only `math` stdlib (no `numpy` dependency) — first `nova compile` works with just `pip install nova-typst matplotlib`
- Add unit test for `.gitignore` content

## Test plan

- [x] `cargo test -p novatype-cli -- init` — 8/8 pass
- [x] `cargo fmt` — clean
- [x] `cargo clippy` — clean

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)